### PR TITLE
Save DHT keys to a binary file

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,27 @@ packets you can change log level to `trace` for `tox_node`:
 ```sh
 RUST_LOG=tox_node=trace cargo run --release
 ```
+
+## Keys generation
+
+In order to run node you have to provide either secret key or path to a keys file.
+
+### Keys file
+
+Keys file is a binary file with sequentially stored public and secret keys. Path
+to a keys file can be specified via `--keys-file` argument. If file doesn't
+exist it will be created with automatically generated keys. The format of this
+file is compatible with `tox-bootstrapd`.
+
+### Secret key
+
+Secret key is a hexadecimal string of size 32 bytes. It can be specified via
+`--secret-key` argument. Any random string will fit but note that only strong
+random generators should be used to generate a secret key. Here are some
+examples how you can do it in the terminal:
+
+```sh
+openssl rand -hex 32
+hexdump -n 32 -e '8 "%08x" 1 "\n"' /dev/random
+od -vN 32 -An -tx1 /dev/random | tr -d " \n" ; echo
+```

--- a/src/cli_config.rs
+++ b/src/cli_config.rs
@@ -32,6 +32,8 @@ impl FromStr for ThreadsConfig {
 /// Config parsed from command line arguments.
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub struct CliConfig {
+    /// Path to the file where DHT keys are stored.
+    pub keys_file: String,
     /// List of bootstrap nodes.
     pub bootstrap_nodes: Vec<PackedNode>,
     /// Number of threads for execution.
@@ -45,6 +47,12 @@ pub fn cli_parse() -> CliConfig {
         .author(crate_authors!("\n"))
         .about(crate_description!())
         .setting(AppSettings::ColoredHelp)
+        .arg(Arg::with_name("keys-file")
+            .short("k")
+            .long("keys-file")
+            .help("Path to the file where DHT keys are stored")
+            .default_value("keys")
+            .takes_value(true))
         .arg(Arg::with_name("bootstrap-node")
             .short("b")
             .long("bootstrap-node")
@@ -62,6 +70,8 @@ pub fn cli_parse() -> CliConfig {
             .takes_value(true)
             .default_value("1"))
         .get_matches();
+
+    let keys_file = value_t!(matches.value_of("keys-file"), String).unwrap_or_else(|e| e.exit());
 
     let bootstrap_nodes = matches
         .values_of("bootstrap-node")
@@ -86,6 +96,7 @@ pub fn cli_parse() -> CliConfig {
     let threads_config = value_t!(matches.value_of("threads"), ThreadsConfig).unwrap_or_else(|e| e.exit());
 
     CliConfig {
+        keys_file,
         bootstrap_nodes,
         threads_config,
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -121,7 +121,13 @@ fn main() {
     let socket = bind_socket(local_addr);
     let (sink, stream) = UdpFramed::new(socket, DhtCodec).split();
 
-    let (dht_pk, dht_sk) = load_or_gen_keys(cli_config.keys_file);
+    let (dht_pk, dht_sk) = if let Some(sk) = cli_config.sk {
+        (sk.public_key(), sk)
+    } else if let Some(keys_file) = cli_config.keys_file {
+        load_or_gen_keys(keys_file)
+    } else {
+        panic!("Neither secret key nor keys file is specified")
+    };
     info!("DHT public key: {}", hex::encode(dht_pk.as_ref()).to_uppercase());
 
     // Create a channel for server to communicate with network


### PR DESCRIPTION
This pr uses the same file format as `tox-bootstrapd`.